### PR TITLE
List By month/week/year.

### DIFF
--- a/src/components/Graphs/BarGraph.tsx
+++ b/src/components/Graphs/BarGraph.tsx
@@ -14,6 +14,7 @@ import PaginatedButtons from "./PaginatedButtons";
 interface GraphLabels{
   quantities: number[],
   profits: any[],
+  dates: any[],
   cartLength: number,
   currentPage: number,
   setCurrentPage: (e:number) => void,
@@ -54,14 +55,8 @@ ChartJS.register(
 
 export default function BarGraph(props:GraphLabels){
 
-  const labels = [];
-
-  for(let i = 1; i <= props.rowsPerPage; i++){
-    labels.push(`Purchase ${i}`)
-  }
-
     const data = {
-        labels: labels,
+        labels: props.dates.slice(props.startIndex, props.endIndex),
         datasets: [
           {
             label: 'Quantities Sold',

--- a/src/components/Graphs/HorizontalBarGraph.tsx
+++ b/src/components/Graphs/HorizontalBarGraph.tsx
@@ -39,6 +39,7 @@ export const options = {
 interface GraphLabels{
     profits: any[],
     quantities: any[],
+    dates: any[],
     cartLength: number,
     currentPage: number,
     setCurrentPage: (e:number) => void,
@@ -50,15 +51,8 @@ interface GraphLabels{
 
 export default function HorizontalBarGraph(props:GraphLabels){
 
-    const labels = []
-
-    for(let i = 1; i <= props.rowsPerPage; i++){
-      labels.push(`Purchase ${i}`)
-    }
-
-
     const data = {
-        labels: labels,
+        labels: props.dates.slice(props.startIndex, props.endIndex),
         datasets: [
           {
             label: "Quantities",

--- a/src/components/Graphs/LineGraph.tsx
+++ b/src/components/Graphs/LineGraph.tsx
@@ -14,7 +14,8 @@ import PaginatedButtons from "./PaginatedButtons"
 
 interface GraphLabels {
   quantities: number[],
-  profits: any[]
+  profits: any[],
+  dates: any[],
   cartLength: number,
   currentPage: number,
   setCurrentPage: (e: number) => void,
@@ -48,14 +49,8 @@ ChartJS.register(
 
 export default function LineGraph(props:GraphLabels){
 
-    const labels = []
-
-    for(let i = 1; i<= props.rowsPerPage; i++){
-      labels.push(`Purchase ${i}`)
-    }
-
     const data = {
-        labels: labels,
+        labels: props.dates.slice(props.startIndex, props.endIndex),
         datasets: [
           {
             label: 'Quantities Sold',

--- a/src/components/Graphs/List.tsx
+++ b/src/components/Graphs/List.tsx
@@ -1,0 +1,29 @@
+import React, {useState, useEffect} from "react"
+import {DisplayByMonth, DisplayByWeek, DisplayByYear, PurchasedItem, GetPurchases} from "../../hooks/PurchasesHooks"
+import {Button} from "../../components/Button"
+
+export default function List(){
+
+    const [purchases,setPurchases]= useState<PurchasedItem[]>([]);
+    const [display, setDisplay] = useState<string>("week");
+
+    useEffect(()=>{
+        GetPurchases((e:PurchasedItem[])=>setPurchases(e));
+    },[])
+
+    return(
+        <section>
+            <div className="flex buttons justifyBetween">
+                {Button({text: "Week", handleButtonClick: ()=>setDisplay("week")})}
+                {Button({text: "Month", handleButtonClick: ()=>setDisplay("month")})}
+                {Button({text: "Year", handleButtonClick: ()=>setDisplay("year")})}
+            </div>
+
+                {display === "week" ? DisplayByWeek(purchases) : ""}
+                {display === "month" ? DisplayByMonth(purchases) : ""}
+                {display === "year" ? DisplayByYear(purchases) : ""}
+
+            
+        </section>
+    )
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -106,6 +106,9 @@ table td{
     margin: 2rem 2rem 4rem 2rem;
 }
 
+#purchase tr{
+    width: 100%;
+}
 
 /* Cart
    ========================================================================== */
@@ -431,6 +434,10 @@ input{
 #auth .userDisplays li{
     font-size: 2rem;
     padding: .5rem;
+}
+
+#auth .userDisplays .name{
+    text-transform: capitalize;
 }
 
 #auth .userDisplays{

--- a/src/hooks/LoginHooks.tsx
+++ b/src/hooks/LoginHooks.tsx
@@ -106,7 +106,7 @@ export function DisplayUsers(listOfUsers: User[], currentUser: User, startIndex:
             let updatedAtTimeMinutes:number = parseInt(user.$updatedAt.split("T")[1].split(".")[0].split(":")[1]);
               return(
                 <ul key = {user.$id} className = "flex flex-col alignCenter userDisplays">
-                  <li>{user.name}</li>
+                  <li className = "name">{user.name}</li>
                   <li>Employee Id: {user.$id}</li>
                   <li>Employee Email: {user.email}</li>
                   <li>Created At: {createdAtDate}  {createdAtTimeHours > 12 ? createdAtTimeHours -= 12 : createdAtTimeHours}{":" + createdAtTimeMinutes}{createdAtTimeHours > 12 ? "PM" : "AM"}</li>

--- a/src/pages/employee/Purchases.tsx
+++ b/src/pages/employee/Purchases.tsx
@@ -4,8 +4,8 @@ import Footer from "../../components/Footer"
 import BarGraph from "../../components/Graphs/BarGraph"
 import LineGraph from "../../components/Graphs/LineGraph"
 import HorizontalBarGraph from "../../components/Graphs/HorizontalBarGraph"
-
-import {GetPurchasedProfit, GetPurchases, PurchasedItem, GetPurchasedQuantities} from "../../hooks/PurchasesHooks"
+import List from "../../components/Graphs/List"
+import {GetPurchasedProfit, GetPurchases, PurchasedItem, GetPurchasedQuantities, GetPurchasedDates} from "../../hooks/PurchasesHooks"
 import {Button} from "../../components/Button"
 
 export default function Purchases(){
@@ -22,7 +22,6 @@ export default function Purchases(){
         GetPurchases((e:PurchasedItem[])=>setPurchases(e));
     },[])
 
-
     return(
         <main id = "purchase">
             <Nav pageHeading = {"Purchase History"}/>
@@ -33,22 +32,24 @@ export default function Purchases(){
                         {Button({text:"", handleButtonClick: ()=>setDisplay("bar"), classNames: "fa-solid fa-chart-column"})}
                         {Button({text:"", handleButtonClick: ()=>setDisplay("line"), classNames: "fa-solid fa-chart-line"})}
                         {Button({text:"", handleButtonClick: ()=>setDisplay("horizontalBar"), classNames: "fa-solid fa-chart-bar"})}
-
+                        {Button({text:"", handleButtonClick: ()=>setDisplay("list"), classNames: "fa-solid fa-list"})}
                     </section>
 
                     <section className = "graph">
-                        {display === "bar" ? <BarGraph cartLength = {purchases.length} profits = {GetPurchasedProfit(purchases)} quantities ={GetPurchasedQuantities(purchases)} currentPage = {currentPage} setCurrentPage={(e:number)=>setCurrentPage(e)} rowsPerPage = {rowsPerPage} startIndex = {startIndex} endIndex = {endIndex}/> : ""}
+                        {display === "bar" ? <BarGraph cartLength = {purchases.length} dates = {GetPurchasedDates(purchases)} profits = {GetPurchasedProfit(purchases)} quantities ={GetPurchasedQuantities(purchases)} currentPage = {currentPage} setCurrentPage={(e:number)=>setCurrentPage(e)} rowsPerPage = {rowsPerPage} startIndex = {startIndex} endIndex = {endIndex}/> : ""}
                     </section>
 
                     <section className = "graph">
-                        {display === "line" ? <LineGraph cartLength = {purchases.length} profits = {GetPurchasedProfit(purchases)} quantities ={GetPurchasedQuantities(purchases)} currentPage = {currentPage} setCurrentPage={(e:number)=>setCurrentPage(e)} rowsPerPage = {rowsPerPage} startIndex = {startIndex} endIndex = {endIndex}/> : ""}
+                        {display === "line" ? <LineGraph cartLength = {purchases.length} dates = {GetPurchasedDates(purchases)} profits = {GetPurchasedProfit(purchases)} quantities ={GetPurchasedQuantities(purchases)} currentPage = {currentPage} setCurrentPage={(e:number)=>setCurrentPage(e)} rowsPerPage = {rowsPerPage} startIndex = {startIndex} endIndex = {endIndex}/> : ""}
                     </section>
 
                     <section className ="graph">
-                        {display === "horizontalBar" ? <HorizontalBarGraph quantities = {GetPurchasedQuantities(purchases)} cartLength = {purchases.length} profits = {GetPurchasedProfit(purchases)} currentPage = {currentPage} setCurrentPage = {(e:number)=>setCurrentPage(e)} rowsPerPage={rowsPerPage} startIndex = {startIndex} endIndex={endIndex}/> : ""}
+                        {display === "horizontalBar" ? <HorizontalBarGraph dates = {GetPurchasedDates(purchases)} quantities = {GetPurchasedQuantities(purchases)} cartLength = {purchases.length} profits = {GetPurchasedProfit(purchases)} currentPage = {currentPage} setCurrentPage = {(e:number)=>setCurrentPage(e)} rowsPerPage={rowsPerPage} startIndex = {startIndex} endIndex={endIndex}/> : ""}
                     </section>
 
-                        
+                    <section className = "graph">
+                        {display === "list" ? <List/> : ""}
+                    </section>
 
                 </section>
             <Footer/>


### PR DESCRIPTION
List the purchase history by the current week, the current month or the current year, and it allows the administrator user to toggle between the three different toggle options.  Also change the graphs labels so each purchase is represented by the date of the purchase.