### PR TITLE
EditAppointment UI & Purchase List pagination

### DIFF
--- a/src/components/Graphs/List.tsx
+++ b/src/components/Graphs/List.tsx
@@ -2,7 +2,15 @@ import React, {useState, useEffect} from "react"
 import {DisplayByMonth, DisplayByWeek, DisplayByYear, PurchasedItem, GetPurchases} from "../../hooks/PurchasesHooks"
 import {Button} from "../../components/Button"
 
-export default function List(){
+interface ListLabels{
+    currentPage: number,
+    setCurrentPage: (e:number) => void,
+    rowsPerPage: number,
+    startIndex: number,
+    endIndex: number
+}
+
+export default function List(props: ListLabels){
 
     const [purchases,setPurchases]= useState<PurchasedItem[]>([]);
     const [display, setDisplay] = useState<string>("week");
@@ -19,9 +27,10 @@ export default function List(){
                 {Button({text: "Year", handleButtonClick: ()=>setDisplay("year")})}
             </div>
 
-                {display === "week" ? DisplayByWeek(purchases) : ""}
-                {display === "month" ? DisplayByMonth(purchases) : ""}
-                {display === "year" ? DisplayByYear(purchases) : ""}
+
+                {display === "week" ? DisplayByWeek({purchases: purchases, startIndex: props.startIndex, endIndex: props.endIndex, currentPage: props.currentPage, rowsPerPage: props.rowsPerPage, setCurrentPage: (e:number)=>props.setCurrentPage(e)}) : ""}
+                {display === "month" ? DisplayByMonth({purchases: purchases, startIndex: props.startIndex, endIndex: props.endIndex, currentPage: props.currentPage, rowsPerPage: props.rowsPerPage, setCurrentPage: (e:number)=>props.setCurrentPage(e)}) : ""}
+                {display === "year" ? DisplayByYear({purchases: purchases, startIndex: props.startIndex, endIndex: props.endIndex, currentPage: props.currentPage, rowsPerPage: props.rowsPerPage, setCurrentPage: (e:number)=>props.setCurrentPage(e)}) : ""}
 
             
         </section>

--- a/src/components/PurchaseNav.tsx
+++ b/src/components/PurchaseNav.tsx
@@ -1,0 +1,5 @@
+import React from "react"
+
+export default function PurchaseNav(){
+
+}

--- a/src/hooks/ManageAppointmentHooks.tsx
+++ b/src/hooks/ManageAppointmentHooks.tsx
@@ -47,10 +47,25 @@ export function displayAppointments(appointments: Appointment[], classNameContai
 
         const currentHours = currentDate.getHours();
     
-    const fullCurrentDate = `${currentMonth}/${currentDay}/${currentYear}` 
-
+        const apptMonth = parseInt(appointmentDate.split("/")[0])
+        const apptDate =  parseInt(appointmentDate.split("/")[1])
+        const apptYear =  parseInt(appointmentDate.split("/")[2])
+   
+        function checkExpired(){
+            if(apptYear<currentYear){
+                return false
+            }else if(apptMonth<currentMonth){
+                return false
+            }else if(apptDate<currentDay){
+                return false
+            }else if(apptYear >= currentYear && apptMonth >= currentMonth && apptDate >= currentDay){
+                return true
+            }
+        }
+    
+            
          return(
-             <div key = {i} className = {`${classNameContainer} ${(appointmentDate > fullCurrentDate) || (appointmentDate === fullCurrentDate && appointmentTime <= currentHours) ? "" : "expired"}`}>
+             <div key = {i} className = {`${classNameContainer} ${(checkExpired() && appointmentTime <= currentHours) ? "" : "expired"}`}>
                 <section className = {classNameContainer === "appointmentContainer" ? "flex flex-col" : "flex justifyBetween"}>
                  <div className = "flex alignCenter">
                     <h1>{appointment.firstName} {appointment.lastName}</h1>
@@ -59,7 +74,7 @@ export function displayAppointments(appointments: Appointment[], classNameContai
                  </div>
           
                  <div className = "flex">
-                 <h1 className = {(appointmentDate > fullCurrentDate) || (appointmentDate === fullCurrentDate && appointmentTime <= currentHours) ? "" : "expired"}>{appointmentDate}</h1>
+                 <h1>{appointmentDate}</h1>
                  {classNameContainer === "appointmentContainer" ? "" : <h1>{appointmentDayoFWeek}</h1>}
                  <h1>{appointmentTime > 12 ? (appointmentTime -12).toString() + ":00PM" : appointmentTime + ":00AM"}</h1>
                  </div>
@@ -77,10 +92,10 @@ export function displayAppointments(appointments: Appointment[], classNameContai
                  </section>
 
                 <div className = "flex alignCenter">
-                {(appointmentDate > fullCurrentDate) || (appointmentDate === fullCurrentDate && appointmentTime <= currentHours) 
+                {(checkExpired() && appointmentTime <= currentHours) 
                 ? <button className = "button" onClick = {()=>NotifyClient(appointment.email, appointment.service, appointment.carYear, appointment.carModel, appointment.carMake, appointment.$id)}>Notify client that Car is ready</button>                : 
                    <h2>Expired Apppointment</h2> }
-                    <i className = {(appointmentDate > fullCurrentDate) || (appointmentDate === fullCurrentDate && appointmentTime <= currentHours) ? "" : "fa-solid fa-triangle-exclamation"}></i>
+                    <i className = {(checkExpired() && appointmentTime <= currentHours) ? "" : "fa-solid fa-triangle-exclamation"}></i>
                 </div>
            
              </div>

--- a/src/hooks/PurchasesHooks.tsx
+++ b/src/hooks/PurchasesHooks.tsx
@@ -1,5 +1,6 @@
 import api from "../api/api"
 import {Query} from "appwrite"
+import PaginatedButtons from "../components/Graphs/PaginatedButtons"
 
 export interface PurchasedItem{
     $createdAt: string,
@@ -54,10 +55,10 @@ export interface Date{
     totalProfit?: number
  }
 
-export function DisplayByYear(purchases: PurchasedItem[]){
+export function DisplayByYear(props: DisplayBy){
     const date = new Date();
     const currentYear = date.getFullYear();
-    const purchasedDates = GetPurchasedDates(purchases);
+    const purchasedDates = GetPurchasedDates(props.purchases);
     const filteredDates = purchasedDates.filter((date:Date | undefined)=>date?.date.includes(currentYear.toString()))
     const tableData = filteredDates.map((date: Date | undefined, i:number)=>{
         return(
@@ -67,43 +68,12 @@ export function DisplayByYear(purchases: PurchasedItem[]){
                 <td>${date?.totalProfit}</td>
             </tr>
         )
-    })
+    }).slice(props.startIndex, props.endIndex)
 
     return(
-        <table>
-            <thead>
-                <tr>
-                    <th>Date</th>
-                    <th>Quantities Sold</th>
-                    <th>Profit Made</th>
-                </tr>
-            </thead>
-            <tbody>
-                {tableData}
-            </tbody>
-        </table>
-    )
- }
-
- export function DisplayByMonth(purchases: PurchasedItem[]){
-    const date = new Date();
-    const currentMonth = date.getMonth()+1;
-    const currentYear = date.getFullYear();
-    const purchasedDates = GetPurchasedDates(purchases);
-    const filteredDates = purchasedDates.filter((date:Date | undefined)=>date?.date.split("-")[0].includes(currentYear.toString()) && date?.date.split("-")[1].includes(currentMonth.toString()))
-    
-    if(filteredDates.length){
-        const tableData = filteredDates.map((date: Date | undefined, i:number)=>{
-            return(
-            <tr key = {`month-${i}`} className = {`${i % 2 === 0 ? "even" : "odd"}`}>
-                <td>{date?.date}</td>
-                <td>{date?.quantityTotal}</td>
-                <td>${date?.totalProfit}</td>
-            </tr>
-            )
-        })
-
-        return(
+        <section>
+            <PaginatedButtons className = "flex" currentPage = {props.currentPage} cartLength = {filteredDates.length} setCurrentPage = {(e:number)=>props.setCurrentPage(e)} rowsPerPage={props.rowsPerPage}/>
+            
             <table>
                 <thead>
                     <tr>
@@ -116,12 +86,60 @@ export function DisplayByYear(purchases: PurchasedItem[]){
                     {tableData}
                 </tbody>
             </table>
+        </section>
+    )
+ }
+
+ export function DisplayByMonth(props: DisplayBy){
+    const date = new Date();
+    const currentMonth = date.getMonth()+1;
+    const currentYear = date.getFullYear();
+    const purchasedDates = GetPurchasedDates(props.purchases);
+    const filteredDates = purchasedDates.filter((date:Date | undefined)=>date?.date.split("-")[0].includes(currentYear.toString()) && date?.date.split("-")[1].includes(currentMonth.toString()))
+    
+    if(filteredDates.length){
+        const tableData = filteredDates.map((date: Date | undefined, i:number)=>{
+            return(
+            <tr key = {`month-${i}`} className = {`${i % 2 === 0 ? "even" : "odd"}`}>
+                <td>{date?.date}</td>
+                <td>{date?.quantityTotal}</td>
+                <td>${date?.totalProfit}</td>
+            </tr>
+            )
+        }).slice(props.startIndex, props.endIndex)
+
+        return(
+            <section>
+                <PaginatedButtons className = "flex" currentPage = {props.currentPage} cartLength = {filteredDates.length} setCurrentPage = {(e:number)=>props.setCurrentPage(e)} rowsPerPage={props.rowsPerPage}/>
+
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Quantities Sold</th>
+                            <th>Profit Made</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {tableData}
+                    </tbody>
+                </table>
+            </section>
+           
         )
     }
  }
 
+ interface DisplayBy{
+    purchases: PurchasedItem[], 
+    startIndex: number, 
+    endIndex: number, 
+    currentPage: number,
+    setCurrentPage: (e:number)=>void,
+    rowsPerPage: number
+ }
 
- export function DisplayByWeek(purchases: PurchasedItem[]){
+ export function DisplayByWeek(props: DisplayBy){
     const date = new Date();
     let currentDay = date.getDate();
     let currentMonth = date.getMonth()+1;
@@ -169,7 +187,7 @@ export function DisplayByYear(purchases: PurchasedItem[]){
         return currentWeek.filter((day:number)=>day===Number(date))
     }   
       
-    const purchasedDates = GetPurchasedDates(purchases);
+    const purchasedDates = GetPurchasedDates(props.purchases);
     const filteredDates = purchasedDates.filter((date:Date | undefined)=>date?.date.split("-")[0].includes(currentYear.toString()) && date?.date.split("-")[1].includes(currentMonth.toString()) && filterDate(date?.date.split("-")[2])[0])
 
     const tableData = filteredDates.map((date: Date | undefined, i: number)=>{
@@ -180,9 +198,11 @@ export function DisplayByYear(purchases: PurchasedItem[]){
                 <td>${date?.totalProfit}</td>
             </tr>
         )
-    })
+    }).slice(props.startIndex, props.endIndex)
 
     return(
+        <section>
+            <PaginatedButtons className = "flex" currentPage = {props.currentPage} cartLength = {filteredDates.length} setCurrentPage = {(e:number)=>props.setCurrentPage(e)} rowsPerPage={props.rowsPerPage}/>
         <table>
             <thead>
                 <tr>
@@ -195,6 +215,8 @@ export function DisplayByYear(purchases: PurchasedItem[]){
                 {tableData}
             </tbody>
         </table>
+        </section>
+     
     )
  }
 

--- a/src/hooks/ReservationHooks.tsx
+++ b/src/hooks/ReservationHooks.tsx
@@ -402,7 +402,6 @@ export function DisplayTimeDateAppointments(props: TimeDateAppointments):React.J
             currentDayOfWeek = 0
         }
 
-
         if(props.date?.split("D")[0] === `${currentMonth}/${currentDay}/${currentYear}`){
             appt.push(
                 <div className = {`calendar clearButton c-${i} clicked`} key = {`c-${i}`} onClick = {()=>{
@@ -435,7 +434,6 @@ export function DisplayTimeDateAppointments(props: TimeDateAppointments):React.J
     }
 
 
-
     const filterAppointmentTimes = props.appointments.filter((appointment:Appointment) => appointment.date.split("D")[0] === selectedDate)
  
     const appointmentTimes = filterAppointmentTimes.map((appointment:Appointment) => appointment.time)
@@ -466,13 +464,25 @@ export function DisplayTimeDateAppointments(props: TimeDateAppointments):React.J
         })
 
         //render clear buttons of appointment dates
-        const finalJSX = miliaryTimeConversion.map((jsx,i)=>{return(
+        const finalJSX = miliaryTimeConversion.map((jsx,i)=>{
+            if(jsx[1] === props.time){
+                return(
+                <button 
+                className = {`clearButton t-${i} time clicked`} key = {i}
+                onClick = {(e: React.MouseEvent<HTMLButtonElement, MouseEvent>)=>handleChangeTime({i: i, e: e, time: jsx[1], setTime: (e:string)=>props.setTime(e)})}>
+                    {jsx[0]}
+                </button>
+                )
+            }else{
+            return(
             <button 
                   className = {`clearButton t-${i} time`} key = {i}
-                  onClick = {(e: React.MouseEvent<HTMLButtonElement, MouseEvent>)=>handleChangeTime({i: i,e: e,time: jsx[1],setTime: (e:string)=>props.setTime(e)})}>
+                  onClick = {(e: React.MouseEvent<HTMLButtonElement, MouseEvent>)=>handleChangeTime({i: i, e: e, time: jsx[1], setTime: (e:string)=>props.setTime(e)})}>
                       {jsx[0]}
             </button>
-        )})
+                 )
+            }
+    })
 
 
         return(

--- a/src/pages/employee/EditAppointment.tsx
+++ b/src/pages/employee/EditAppointment.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useMemo} from "react"
+import React, {useState, useEffect} from "react"
 import Nav from "../../components/Nav"
 import {getAppointmentData, Appointment, DisplayTimeDateAppointments, GetCarData, SelectCarMakeInput, SelectCarModelInput, SelectCarYearInput, ChooseCarService, Input, TextBoxInput} from "../../hooks/ReservationHooks"
 import { EditChooseTwoInput, handleEditAppointment, checkDate, getEditAppointmentData } from "../../hooks/EditAppointmentHooks"
@@ -29,7 +29,7 @@ export default function EditAppointment(){
     const [appointments, setAppointments] = useState<Appointment[]>([]);
     const [warning, setWarning] = useState<string>("");
 
-    useMemo(()=>{
+    useEffect(()=>{
         GetCarData({onMakeSelect: setCarMakeOptions, onModelSelect: setCarModelOptions, onYearSelect: setCarYearOptions, carMake: carMake, carModel:carModel});
 
         getAppointmentData((e:Appointment[])=>setAppointments(e))
@@ -57,39 +57,39 @@ export default function EditAppointment(){
                 <div className = "flex justifyBetween">
 
                     <section className = "section-1 flex flex-col alignCenter">
-                        <section className = "flex flex-col alignCenter">
+                     <section className = "flex flex-col alignCenter">
                             {SelectCarMakeInput({defaultValue: data.carMake, options: carMakeOptions, onChange: (e:string)=>setCarMake(e), carMake: carMake, carYear: carYear, carModel: carModel, resetModel: (e:string)=>setCarModel(e), resetYear:(e:string)=>setCarYear(e), resetMake:(e:string)=>setCarMake(e)})}
                             {SelectCarModelInput({defaultValue: data.carModel, options: carModelOptions, onChange: (e:string)=>setCarModel(e), carMake: carMake, carModel: carModel, carYear: carYear, resetModel:(e:string)=>setCarModel(e), resetYear: (e:string)=>setCarYear(e), resetMake:(e:string)=>setCarMake})}
                             {SelectCarYearInput({defaultValue: data.carYear, options: carYearOptions, onChange: (e:string)=>setCarYear(e), carMake: carMake, carModel: carModel, carYear: carYear, resetModel:(e:string)=>setCarModel(e),resetYear:(e:string)=>setCarYear(e),resetMake:(e:string)=>setCarMake(e)})}
                         </section>
-                        
-                    {EditChooseTwoInput({defaultValue: data.stayLeave, text1:"Wait for car",text2: "Drop off car",name: "stayLeave" ,onChange: (e:string)=>setStay_Leave(e)})}
+                 
+                        {EditChooseTwoInput({defaultValue: data.stayLeave, text1:"Wait for car",text2: "Drop off car",name: "stayLeave" ,onChange: (e:string)=>setStay_Leave(e)})}
 
-                    {ChooseCarService((e:string)=>setService(e), data.service)}
+{ChooseCarService((e:string)=>setService(e), data.service)}
 
-                    </section>
+</section>
 
-                    <section className = "section-1 flex flex-col alignCenter">
-                        <section className = "flex justifyBetween contact">
-                            {Input({type: "text", onChange: (e:string)=>setFirstName(e), placeholder: data.firstName, defaultValue: data.firstName})}
-                            {Input({type: "text", onChange: (e:string)=>setLastName(e), placeholder: data.lastName, defaultValue: data.lastName})}
-                        </section>
+<section className = "section-1 flex flex-col alignCenter">
+    <section className = "flex justifyBetween contact">
+        {Input({type: "text", onChange: (e:string)=>setFirstName(e), placeholder: data.firstName, defaultValue: data.firstName})}
+        {Input({type: "text", onChange: (e:string)=>setLastName(e), placeholder: data.lastName, defaultValue: data.lastName})}
+    </section>
 
-                        <section className = "flex justifyBetween contact">
-                            {Input({type: "text", onChange: (e:string)=>setEmail(e), placeholder: data.email, defaultValue: data.email})}
-                            {Input({type: "tel", onChange: (e:string)=>setPhone(e), placeholder: data.phone, minlength: 10, maxlength: 10, defaultValue: data.phone})}
-                        </section>
+    <section className = "flex justifyBetween contact">
+        {Input({type: "text", onChange: (e:string)=>setEmail(e), placeholder: data.email, defaultValue: data.email})}
+        {Input({type: "tel", onChange: (e:string)=>setPhone(e), placeholder: data.phone, minlength: 10, maxlength: 10, defaultValue: data.phone})}
+    </section>
 
-                        {Input({type: "text", onChange: (e:string)=>setZipCode(e), placeholder: data.zipCode, minlength: 5, maxlength: 5, defaultValue: data.zipCode})}
+    {Input({type: "text", onChange: (e:string)=>setZipCode(e), placeholder: data.zipCode, minlength: 5, maxlength: 5, defaultValue: data.zipCode})}
 
-                        <div className="flex flex-col alignCenter contact">
-                            <h2>Preferred Contact Method</h2>
+    <div className="flex flex-col alignCenter contact">
+        <h2>Preferred Contact Method</h2>
 
-                            {EditChooseTwoInput({defaultValue: data.contact, text1:"Email",text2: "Phone",name: "contact" ,onChange: (e:string)=>setContact(e)})}
-                            {TextBoxInput({width: 50, height: 10, onChange: (e:string)=>setComment(e), placeholder: data.comment || "Additional Comments"})}
-                        </div>
+        {EditChooseTwoInput({defaultValue: data.contact, text1:"Email",text2: "Phone",name: "contact" ,onChange: (e:string)=>setContact(e)})}
+        {TextBoxInput({width: 50, height: 10, onChange: (e:string)=>setComment(e), placeholder: data.comment || "Additional Comments"})}
+    </div>
 
-                    </section>
+</section> 
 
 
 

--- a/src/pages/employee/Purchases.tsx
+++ b/src/pages/employee/Purchases.tsx
@@ -48,7 +48,7 @@ export default function Purchases(){
                     </section>
 
                     <section className = "graph">
-                        {display === "list" ? <List/> : ""}
+                        {display === "list" ? <List setCurrentPage={(e:number)=>setCurrentPage(e)} currentPage={currentPage} rowsPerPage = {rowsPerPage} startIndex={startIndex} endIndex={endIndex}/> : ""}
                     </section>
 
                 </section>


### PR DESCRIPTION
Fixed the editAppointment UI error so now the expiration date display logic functions correctly and if the appointment date is a current or future date clickable from the editAppointment calendar hub, the button will change to be clicked.  Also added pagination to the list of purchases.

![screencapture-localhost-3000-purchases-2023-09-21-15_18_57](https://github.com/choir27/AutoAligners/assets/66279068/328298ec-a1ef-4e7e-8122-04d800379784)

![screencapture-localhost-3000-editAppointment-2023-09-21-15_17_53](https://github.com/choir27/AutoAligners/assets/66279068/a0d5ec03-f7c1-46df-84da-3c177970f083)

